### PR TITLE
Use paste-and-indent as default Cmd-V action, to preserve indentation.

### DIFF
--- a/config/sublime-text-2/Default (OSX).sublime-keymap
+++ b/config/sublime-text-2/Default (OSX).sublime-keymap
@@ -1,0 +1,4 @@
+[
+  { "keys": ["super+v"], "command": "paste_and_indent" },
+  { "keys": ["super+shift+v"], "command": "paste" }
+]


### PR DESCRIPTION
Switch paste-and-indent (default cmd-shift-v) and paste (default cmd-v) key mappings, to by default save indentation when pasting.
